### PR TITLE
changes and refactors to support several saml providers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,40 @@
+{
+  "browser" : true,
+  "node" : true,
+
+  "bitwise" : true,
+  "camelcase" : false,
+  "curly" : true,
+  "eqeqeq" : true,
+  "forin" : true,
+  "freeze" : true,
+  "immed" : true,
+  "indent" : 2,
+  "latedef" : "nofunc",
+  "maxcomplexity" : 15,
+  "newcap" : true,
+  "noarg" : true,
+  "nonew" : true,
+  "plusplus" : false,
+  "quotmark" : "single",
+  "strict" : true,
+  "trailing" : true,
+  "undef" : true,
+  "unused" : "vars",
+
+  "globalstrict" : true,
+  "laxbreak" : true,
+
+  "globals" : {
+    "after" : true,
+    "afterEach" : true,
+    "angular" : true,
+    "before" : true,
+    "beforeEach" : true,
+    "define" : true,
+    "describe" : true,
+    "expect" : true,
+    "it" : true,
+    "URI" : true
+  }
+}

--- a/lib/getVersion.js
+++ b/lib/getVersion.js
@@ -1,15 +1,17 @@
-module.exports = function(assertion) {
+'use strict';
+
+module.exports = function getVersion(assertion) {
 	if (!assertion) {
 		return null;
-	};
-	
+	}
+
 	if (assertion['@'].MajorVersion === '1') {
 		return '1.1';
 	}
-		
+
 	if (assertion['@'].Version === '2.0') {
 		return '2.0';
 	}
-		
+
 	return null;
-}
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,53 +1,46 @@
-var xml2js = require('xml2js');
-var xmlCrypto = require('xml-crypto');
-var crypto = require('crypto');
-var xmldom = require('xmldom');
-var querystring = require('querystring');
+'use strict';
 
+var xml2js = require('xml2js');
 var getVersion = require('./getVersion.js');
 var validateSignature = require('./validateSignature.js');
-
-// Token Handlers for versions supported
 var tokenHandlers = {
 	'1.1': require('./saml11.js'),
 	'2.0': require('./saml20.js')
-}
+};
 
 var saml = module.exports;
 
-saml.parse = function (rawAssertion, cb) {
-
+saml.parse = function parse(rawAssertion, cb) {
 	if (!rawAssertion) {
 		cb(new Error('rawAssertion is required.'));
 		return;
-	};
+	}
 
-	parseXmlAndVersion(rawAssertion, function(err, assertion, version){
+	parseXmlAndVersion(rawAssertion, function onParse(err, assertion, version) {
 		if (err) {
 			cb(err);
 			return;
-		};
+		}
 
 		parseAttributes(assertion, tokenHandlers[version], cb);
 	});
-}
+};
 
-saml.validate = function (rawAssertion, options, cb) {
-
+saml.validate = function validate(rawAssertion, options, cb) {
 	if (!rawAssertion) {
 		cb(new Error('rawAssertion is required.'));
 		return;
-	};
+	}
 
 	if (!options || (!options.publicKey && !options.thumbprint)) {
 		cb(new Error('publicKey or thumbprint are options required.'));
 		return;
-	};
+	}
 
 	var isSignatureValid = false;
 
 	try {
-		isSignatureValid = validateSignature(rawAssertion, options.publicKey, options.thumbprint)
+		isSignatureValid = validateSignature(rawAssertion, options.publicKey, options.thumbprint);
 	}
 	catch (e) {
 		var error = new Error('Invalid assertion.');
@@ -61,50 +54,69 @@ saml.validate = function (rawAssertion, options, cb) {
 		return;
 	}
 
-	parseXmlAndVersion(rawAssertion, function(err, assertion, version) {
+	parseXmlAndVersion(rawAssertion, function onParse(err, assertion, version) {
 		if (err) {
 			cb(err);
 			return;
-		};
+		}
 
 		var tokenHandler = tokenHandlers[version];
 
 		if (!options.bypassExpiration && !tokenHandler.validateExpiration(assertion)) {
 			cb(new Error('Assertion is expired.'));
-			return;	
-		};
+			return;
+		}
 
 		if (options.audience && !tokenHandler.validateAudience(assertion, options.audience)) {
-			cb(new Error('Invalid audience.'))
+			cb(new Error('Invalid audience.'));
 			return;
-		};	
-		
+		}
+
 		parseAttributes(assertion, tokenHandler, cb);
 	});
-}
+};
 
 function parseXmlAndVersion (rawAssertion, cb) {
-	var parser = new xml2js.Parser({ tagNameProcessors:[xml2js.processors.stripPrefix], attrkey:"@", charKey:"#"});
+	var parser = new xml2js.Parser({
+		attrkey: '@',
+		charKey: '#' ,
+		tagNameProcessors:[xml2js.processors.stripPrefix]
+	});
 
-	parser.parseString(rawAssertion, function (err, assertion) {
+	parser.parseString(rawAssertion, function onParse(err, xml) {
 		if (err) {
 			var error = new Error('An error occurred trying to parse XML assertion.');
 			error.inner = err;
 			cb(error);
 			return;
-		};
+		}
 
-		assertion = assertion.Assertion;
+		xml = xmlBeautify(xml);
 
+		var assertion = xml.Assertion || xml.Response && xml.Response.Assertion;
 		var version = getVersion(assertion);
 
 		if (!version) {
 			cb(new Error('SAML Assertion version not supported.'));
 			return;
-		};
+		}
 
 		cb(null, assertion, version);
 	});
+}
+
+function xmlBeautify(obj) {
+	Object.keys(obj).forEach(function objectForEach(key) {
+		if (obj[key] && obj[key][0] && obj[key].length === 1) {
+			obj[key] = obj[key][0];
+		}
+
+		if (typeof obj[key] === 'object') {
+			return xmlBeautify(obj[key]);
+		}
+	});
+
+	return obj;
 }
 
 function parseAttributes(assertion, tokenHandler, cb) {

--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -1,56 +1,62 @@
+'use strict';
+
+var _ = require('lodash');
 var saml11 = module.exports;
 
-saml11.parse = function (assertion) {
+saml11.parse = function parse(assertion) {
 	var claims = {};
+	var attributes = _.get(assertion, 'AttributeStatement.Attribute');
 
-	if (assertion.AttributeStatement && assertion.AttributeStatement.length > 0) {
-		var attributeStament = assertion.AttributeStatement[0];
+	if (attributes) {
+		attributes = (attributes instanceof Array) ? attributes : [attributes];
 
-		var attributes = attributeStament.Attribute;
+		attributes.forEach(function attributesForEach(attribute) {
+			var attributeName = attribute['@'].AttributeNamespace + '/' + attribute['@'].AttributeName;
 
-		if (attributes) {
-			attributes  = (attributes instanceof Array) ? attributes : [attributes];
+			if (attribute.AttributeValue) {
+				claims[attributeName] = attribute.AttributeValue._ || attribute.AttributeValue;
+			}
+		});
+	}
 
-			attributes.forEach(function (attribute) {
-				var attributeName = attribute['@'].AttributeNamespace + '/' + attribute['@'].AttributeName;
+	var nameIdentifier = _.get(assertion, 'AttributeStament.Subject.NameIdentifier');
 
-				if (attribute.AttributeValue.length == 1) {
-					claims[attributeName] = attribute.AttributeValue[0]['_'] || attribute.AttributeValue[0];
-				} else {
-					claims[attributeName] = attribute.AttributeValue.map(function(v) {
-						return v['_'] || v;
-					});
-				}
-			});
-		}
-
-		if (attributeStament.Subject && attributeStament.Subject.length > 0 && attributeStament.Subject[0].NameIdentifier && attributeStament.Subject[0].NameIdentifier.length > 0) {
-			claims['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier'] = attributeStament.Subject[0].NameIdentifier[0]['_'];
-		}
-	};
+	if (nameIdentifier) {
+		claims['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier'] = nameIdentifier._ || nameIdentifier;
+	}
 
 	return {
+		audience: getAudience(assertion),
 		claims: claims,
 		issuer: assertion['@'].Issuer
+	};
+};
+
+function getAudience(assertion) {
+	if (assertion.Conditions.AudienceRestrictionCondition) {
+		return assertion.Conditions.AudienceRestrictionCondition.Audience;
+	} else {
+		return undefined;
 	}
 }
 
-saml11.validateAudience = function(assertion, realm) {	
+saml11.validateAudience = function validateAudience(assertion, realm) {
+	var audience = getAudience(assertion);
 	if (Array.isArray(realm)) {
-		return realm.indexOf(assertion.Conditions[0].AudienceRestrictionCondition[0].Audience[0]) != -1;
-	};
+		return realm.indexOf(audience) !== -1;
+	}
 
-  	return assertion.Conditions[0].AudienceRestrictionCondition[0].Audience[0] === realm;
-}
+  return audience === realm;
+};
 
-saml11.validateExpiration = function (assertion) {
- 	var notBefore = new Date(assertion.Conditions[0]['@'].NotBefore);
-   	notBefore = notBefore.setMinutes(notBefore.getMinutes() - 10);  // 10 minutes clock skew
+saml11.validateExpiration = function validateExpiration(assertion) {
+	var notBefore = new Date(assertion.Conditions['@'].NotBefore);
+	notBefore = notBefore.setMinutes(notBefore.getMinutes() - 10); // 10 minutes clock skew
 
-  	var notOnOrAfter = new Date(assertion.Conditions[0]['@'].NotOnOrAfter);
-  	notOnOrAfter = notOnOrAfter.setMinutes(notOnOrAfter.getMinutes() + 10);  // 10 minutes clock skew
+	var notOnOrAfter = new Date(assertion.Conditions['@'].NotOnOrAfter);
+  notOnOrAfter = notOnOrAfter.setMinutes(notOnOrAfter.getMinutes() + 10); // 10 minutes clock skew
 
-  	var now = new Date();
+  var now = new Date();
 
-    return !(now < notBefore || now > notOnOrAfter)
- }
+  return !(now < notBefore || now > notOnOrAfter);
+ };

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -1,57 +1,98 @@
-var nameIdentifierClaimType = 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier';
+'use strict';
 
+var nameIdentifierClaimType = 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier';
+var _ = require('lodash');
 var saml20 = module.exports;
 
-saml20.parse = function (assertion) {
-	var claims = {};
+function getClaims(attributes) {
+  var claims = {};
 
-	if (assertion.AttributeStatement && assertion.AttributeStatement.length > 0) {
-		var attributes = assertion.AttributeStatement[0].Attribute;
+  attributes.forEach(function attributesForEach(attribute) {
+    var attributeName = attribute['@'].Name;
 
-		if (attributes) {
-			attributes  = (attributes instanceof Array) ? attributes : [attributes];
+    claims[attributeName] = getProp(attribute, 'AttributeValue');
+  });
 
-			attributes.forEach(function (attribute) {
-				claims[attribute['@'].Name] = attribute.AttributeValue[0];
-			});
+  return claims;
+}
 
-			attributes.forEach(function (attribute) {
-				var attributeName = attribute['@'].Name;
+function trimWords(phrase) {
+  return phrase.split(' ')
+  .map(function wordMapping(w) {
+    return w.trim();
+  })
+  .filter(function wordFiltering(w) {
+    return !!w;
+  })
+  .join(' ');
+}
 
-				if (attribute.AttributeValue.length == 1) {
-					claims[attributeName] = attribute.AttributeValue[0];
-				} else {
-					claims[attributeName] = attribute.AttributeValue;
-				}
-			});
-		}
-	}
+function getProp(obj, prop) {
+  var result = prop ? _.get(obj, prop) : obj;
 
-	if (assertion.Subject[0].NameID) {
-		claims[nameIdentifierClaimType] = assertion.Subject[0].NameID;
-	}
+  if (result && result._) {
+    result = result._;
+  }
 
-	return {
-		claims: claims,
-		issuer: assertion.Issuer[0]
-	}
+  if (typeof result === 'string') {
+    result = trimWords(result);
+
+    return result;
+  }
+  else if (result instanceof Array) {
+    result.forEach(function parseArrayItem(i, ix) {
+      result[ix] = getProp(i);
+    });
+
+    return result;
+  }
+  else {
+    return;
+  }
+}
+
+saml20.parse = function parse(assertion) {
+  var claims = {};
+  var attributes = _.get(assertion, 'AttributeStatement.Attribute');
+
+  if (attributes) {
+    attributes = (attributes instanceof Array) ? attributes : [attributes];
+    claims = getClaims(attributes);
+  }
+
+  var subjectName = getProp(assertion, 'Subject.NameID');
+
+  if (subjectName) {
+    claims[nameIdentifierClaimType] = subjectName;
+  }
+
+  return {
+    audience: getProp(assertion, 'Conditions.AudienceRestriction.Audience'),
+    claims: claims,
+    issuer: getProp(assertion, 'Issuer'),
+    sessionIndex: getProp(assertion, 'AuthnStatement.@.SessionIndex')
+  };
 };
 
-saml20.validateAudience = function (assertion, realm) {
-	if (Array.isArray(realm)) {
-		return realm.indexOf(assertion.Conditions[0].AudienceRestriction[0].Audience[0]) != -1;
-	};
+saml20.validateAudience = function validateAudience(assertion, realm) {
+  var audience = getProp(assertion, 'Conditions.AudienceRestriction.Audience');
 
-  	return assertion.Conditions[0].AudienceRestriction[0].Audience[0] === realm;
+  if (Array.isArray(realm)) {
+    return realm.indexOf(audience) !== -1;
+  }
+
+  return audience === realm;
 };
 
-saml20.validateExpiration = function (assertion) {
- 	var notBefore = new Date(assertion.Conditions[0]['@'].NotBefore);
-   	notBefore = notBefore.setMinutes(notBefore.getMinutes() - 10);  // 10 minutes clock skew
+saml20.validateExpiration = function validateExpiration(assertion) {
+  var dteNotBefore = getProp(assertion, 'Conditions.@.NotBefore');
+  var notBefore = new Date(dteNotBefore);
+  notBefore = notBefore.setMinutes(notBefore.getMinutes() - 10); // 10 minutes clock skew
 
-  	var notOnOrAfter = new Date(assertion.Conditions[0]['@'].NotOnOrAfter);
-  	notOnOrAfter = notOnOrAfter.setMinutes(notOnOrAfter.getMinutes() + 10);  // 10 minutes clock skew
+  var dteNotOnOrAfter = getProp(assertion, 'Conditions.@.NotOnOrAfter');
+  var notOnOrAfter = new Date(dteNotOnOrAfter);
+  notOnOrAfter = notOnOrAfter.setMinutes(notOnOrAfter.getMinutes() + 10); // 10 minutes clock skew
 
-  	var now = new Date();
-    return !(now < notBefore || now > notOnOrAfter)
- }
+  var now = new Date();
+  return !(now < notBefore || now > notOnOrAfter);
+};

--- a/lib/validateSignature.js
+++ b/lib/validateSignature.js
@@ -1,26 +1,24 @@
-var xmlCrypto = require('xml-crypto');
-var crypto = require('crypto');
-var xmldom = require('xmldom');
+'use strict';
+
+var select = require('xml-crypto').xpath;
+var SignedXml = require('xml-crypto').SignedXml;
+var dom = require('xmldom').DOMParser;
 var thumbprint = require('thumbprint');
 
-module.exports = function(xml, cert, certThumbprint) {
-
-  var doc = new xmldom.DOMParser().parseFromString(xml);
-  var signature = xmlCrypto.xpath(doc, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
-
-  var signed = new xmlCrypto.SignedXml(null, {
+module.exports = function validateSignature(xml, cert, certThumbprint) {
+  var doc = new dom().parseFromString(xml);
+  var signature = select(doc, '/*/*/*[local-name(.)=\'Signature\' and namespace-uri(.)=\'http://www.w3.org/2000/09/xmldsig#\']')[0]
+    || select(doc, '/*/*[local-name(.)=\'Signature\' and namespace-uri(.)=\'http://www.w3.org/2000/09/xmldsig#\']')[0];
+  var signed = new SignedXml(null, {
     idAttribute: 'AssertionID'
   });
 
   var calculatedThumbprint;
 
   signed.keyInfoProvider = {
-    getKeyInfo: function(key) {
-      return "<X509Data></X509Data>"
-    },
-    getKey: function(keyInfo) {
+    getKey: function getKey(keyInfo) {
       if (certThumbprint) {
-        var embeddedSignature = keyInfo[0].getElementsByTagNameNS("http://www.w3.org/2000/09/xmldsig#", "X509Certificate");
+        var embeddedSignature = keyInfo[0].getElementsByTagNameNS('http://www.w3.org/2000/09/xmldsig#', 'X509Certificate');
 
         if (embeddedSignature.length > 0) {
           var base64cer = embeddedSignature[0].firstChild.toString();
@@ -32,6 +30,9 @@ module.exports = function(xml, cert, certThumbprint) {
       }
 
       return certToPEM(cert);
+    },
+    getKeyInfo: function getKeyInfo(key) {
+      return '<X509Data></X509Data>';
     }
   };
 
@@ -46,16 +47,15 @@ module.exports = function(xml, cert, certThumbprint) {
   if (certThumbprint) {
     return valid && calculatedThumbprint.toUpperCase() === certThumbprint.toUpperCase();
   }
-}
-
+};
 
 function certToPEM(cert) {
-  if (cert.indexOf("BEGIN CERTIFICATE") === -1 & cert.indexOf("END CERTIFICATE") === -1) {
+  if (cert.indexOf('BEGIN CERTIFICATE') === -1 && cert.indexOf('END CERTIFICATE') === -1) {
     cert = cert.match(/.{1,64}/g).join('\n');
-    cert = "-----BEGIN CERTIFICATE-----\n" + cert;
-    cert = cert + "\n-----END CERTIFICATE-----\n";
+    cert = '-----BEGIN CERTIFICATE-----\n' + cert;
+    cert = cert + '\n-----END CERTIFICATE-----\n';
     return cert;
   } else {
     return cert;
   }
-};
+}

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "SAML 2.0 and 1.1 token parser for Node.js",
   "main": "./lib/index.js",
   "dependencies": {
-    "xml-crypto": "https://github.com/auth0/xml-crypto/tarball/master",
-    "xmldom": "0.1.19",
+    "lodash": "3.10.1",
+    "thumbprint": "0.0.1",
+    "xml-crypto": "0.8.1",
     "xml2js": "0.4.4",
-    "thumbprint": "0.0.1"
+    "xmldom": "0.1.19"
   },
   "repository": {
     "type": "git",
@@ -19,9 +20,14 @@
     "Token Parser"
   ],
   "scripts": {
-    "test": "mocha -R spec test"
+    "test": "npm run jshint && mocha -R spec test",
+    "jshint": "jshint lib/*.js"
   },
   "author": "Leandro Boffi (me@leandrob.com)",
   "license": "MIT",
-  "readmeFilename": "README.md"
+  "readmeFilename": "README.md",
+  "devDependencies": {
+    "jshint": "2.8.0",
+    "mocha": "2.3.3"
+  }
 }


### PR DESCRIPTION
with these changes, it now supports:
- okta
- adfs
- openam
- ping federate
- shibboleth

I also added an editorconfig file and a jshintrc file

tests not changed and still passing (I can add more tests if desired)
