### PR TITLE
Custom reference attribute name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ results
 
 npm-debug.log
 node_modules
+/.idea

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ saml.parse(rawAssertion, function(err, profile) {
 * `publicKey` is the trusted public key.
 * `audience` (optional). If it is included audience validation will take place.
 * `bypassExpiration` (optional). This flag indicates expiration validation bypass (useful for testing, not recommended in production environments);
+* `idAttribute` (optional). This identifier indicate the attribute name that would be used to find the validated root (default is `AttributeId`, while `ID` and `Id` would be used in any case to find the element, so you can omit that option in that cases);
 
 You can use either `thumbprint` or `publicKey` but you should use at least one.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ saml.validate = function validate(rawAssertion, options, cb) {
 	var isSignatureValid = false;
 
 	try {
-		isSignatureValid = validateSignature(rawAssertion, options.publicKey, options.thumbprint);
+		isSignatureValid = validateSignature(rawAssertion, options.publicKey, options.thumbprint, options.idAttribute);
 	}
 	catch (e) {
 		var error = new Error('Invalid assertion.');

--- a/lib/validateSignature.js
+++ b/lib/validateSignature.js
@@ -5,12 +5,12 @@ var SignedXml = require('xml-crypto').SignedXml;
 var dom = require('xmldom').DOMParser;
 var thumbprint = require('thumbprint');
 
-module.exports = function validateSignature(xml, cert, certThumbprint) {
+module.exports = function validateSignature(xml, cert, certThumbprint, idAttribute) {
   var doc = new dom().parseFromString(xml);
   var signature = select(doc, '/*/*/*[local-name(.)=\'Signature\' and namespace-uri(.)=\'http://www.w3.org/2000/09/xmldsig#\']')[0]
     || select(doc, '/*/*[local-name(.)=\'Signature\' and namespace-uri(.)=\'http://www.w3.org/2000/09/xmldsig#\']')[0];
   var signed = new SignedXml(null, {
-    idAttribute: 'AssertionID'
+    idAttribute: idAttribute || 'AssertionID'
   });
 
   var calculatedThumbprint;


### PR DESCRIPTION
In our project we found that we can't validate saml response and the reason is that we have `ResponeID` as referenced attribute 
https://puu.sh/sSnKj/9f7c507188.png
so it's necessary to make it possible to set it while initialization