### PR TITLE
Fix issue where SAML assertion validation fails if namespace is not defined on Signature node.

### DIFF
--- a/lib/validateSignature.js
+++ b/lib/validateSignature.js
@@ -35,7 +35,7 @@ module.exports = function(xml, cert, certThumbprint) {
     }
   };
 
-  signed.loadSignature(signature.toString());
+  signed.loadSignature(signature);
 
   var valid = signed.checkSignature(xml);
 


### PR DESCRIPTION
Remove namespace-breaking reserialization of signature which used to be in the documented example from xml-crypto but was removed due to this bug

See: yaronn/xml-crypto#105

> This is a fix for the example signature validation documentation; the toString() call on the signature node turns out to be harmful, as it removes namespace metadata which would otherwise propagate from the parent document. In situations where the namespace is ds, this works out ok (as ds is provided as a default) but when using other strings for this namespace the example boilerplate fails.
> 
> In the example below, the definition of dsig would be undefined in a toString-orphaned signature, and the canonicalization algorithm would resolve the url as an empty string -- changing the underlying canonical text and causing the SignatureValue verification to fail.
> 
> PR fixes this in the example, which realistically will get used as boilerplate in many integrations of this library. Having just spent three days chasing down the cause of one of our SAML integration failures, I think its a useful change.