### PR TITLE
Ensure that the submitted publicKey matches the one embedded in the SAML

### DIFF
--- a/lib/validateSignature.js
+++ b/lib/validateSignature.js
@@ -14,6 +14,7 @@ module.exports = function validateSignature(xml, cert, certThumbprint) {
   });
 
   var calculatedThumbprint;
+  var certfromSaml;
 
   signed.keyInfoProvider = {
     getKey: function getKey(keyInfo) {
@@ -29,6 +30,8 @@ module.exports = function validateSignature(xml, cert, certThumbprint) {
         }
       }
 
+      certFromSaml = keyInfo[0].getElementsByTagNameNS('http://www.w3.org/2000/09/xmldsig#', 'X509Certificate');
+
       return certToPEM(cert);
     },
     getKeyInfo: function getKeyInfo(key) {
@@ -41,7 +44,7 @@ module.exports = function validateSignature(xml, cert, certThumbprint) {
   var valid = signed.checkSignature(xml);
 
   if (cert) {
-    return valid;
+    return valid && cert === certFromSaml;
   }
 
   if (certThumbprint) {

--- a/lib/validateSignature.js
+++ b/lib/validateSignature.js
@@ -44,8 +44,6 @@ module.exports = function validateSignature(xml, cert, certThumbprint) {
   var valid = signed.checkSignature(xml);
 
   if (cert) {
-    console.log(cert);
-    console.log(certFromSaml)
     return valid && cert === certFromSaml;
   }
 

--- a/lib/validateSignature.js
+++ b/lib/validateSignature.js
@@ -14,7 +14,7 @@ module.exports = function validateSignature(xml, cert, certThumbprint) {
   });
 
   var calculatedThumbprint;
-  var certfromSaml;
+  var certFromSaml;
 
   signed.keyInfoProvider = {
     getKey: function getKey(keyInfo) {
@@ -44,6 +44,8 @@ module.exports = function validateSignature(xml, cert, certThumbprint) {
   var valid = signed.checkSignature(xml);
 
   if (cert) {
+    console.log(cert);
+    console.log(certFromSaml)
     return valid && cert === certFromSaml;
   }
 

--- a/lib/validateSignature.js
+++ b/lib/validateSignature.js
@@ -30,7 +30,7 @@ module.exports = function validateSignature(xml, cert, certThumbprint) {
         }
       }
 
-      certFromSaml = keyInfo[0].getElementsByTagNameNS('http://www.w3.org/2000/09/xmldsig#', 'X509Certificate');
+      certFromSaml = keyInfo[0].getElementsByTagNameNS('http://www.w3.org/2000/09/xmldsig#', 'X509Certificate')[0].firstChild.toString();
 
       return certToPEM(cert);
     },

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "SAML 2.0 and 1.1 token parser for Node.js",
   "main": "./lib/index.js",
   "dependencies": {
-    "lodash": "3.10.1",
+    "lodash": "4.17.10",
     "thumbprint": "0.0.1",
-    "xml-crypto": "0.8.1",
-    "xml2js": "0.4.4",
-    "xmldom": "0.1.19"
+    "xml-crypto": "0.10.1",
+    "xml2js": "0.4.19",
+    "xmldom": "0.1.27"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Just like is done with the thumbprint.

Also updated dependencies to fix audit warnings.