### PR TITLE
Allow passing in idAttribute as an option to validateSignature

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ saml.validate = function validate(rawAssertion, options, cb) {
 	var isSignatureValid = false;
 
 	try {
-		isSignatureValid = validateSignature(rawAssertion, options.publicKey, options.thumbprint);
+		isSignatureValid = validateSignature(rawAssertion, options.publicKey, options.thumbprint, options.idAttribute);
 	}
 	catch (e) {
 		var error = new Error('Invalid assertion.');

--- a/lib/validateSignature.js
+++ b/lib/validateSignature.js
@@ -5,12 +5,12 @@ var SignedXml = require('xml-crypto').SignedXml;
 var dom = require('xmldom').DOMParser;
 var thumbprint = require('thumbprint');
 
-module.exports = function validateSignature(xml, cert, certThumbprint) {
+module.exports = function validateSignature(xml, cert, certThumbprint, idAttribute) {
   var doc = new dom().parseFromString(xml);
   var signature = select(doc, '/*/*/*[local-name(.)=\'Signature\' and namespace-uri(.)=\'http://www.w3.org/2000/09/xmldsig#\']')[0]
     || select(doc, '/*/*[local-name(.)=\'Signature\' and namespace-uri(.)=\'http://www.w3.org/2000/09/xmldsig#\']')[0];
   var signed = new SignedXml(null, {
-    idAttribute: 'AssertionID'
+    idAttribute: idAttribute ? idAttribute : 'AssertionID'
   });
 
   var calculatedThumbprint;


### PR DESCRIPTION
The default value is AssertionId, but when using this to verify a SAML Response, we need to be able to change the ID attribute so that it searches through ResponseID as well.